### PR TITLE
Update install example for Elm 0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # elm-range-slider
 
 ```shell
-elm package install stephenreddek/elm-range-slider
+elm install stephenreddek/elm-range-slider
 ```
 
 ## Usage


### PR DESCRIPTION
The current example for installing in the README includes the `package` sub-command. This isn't not a valid option. Removing `package`, the stated example works as expected:

```
elm install stephenreddek/elm-range-slider
```

Thank you for your work on this range slider element.

