### PR TITLE
Loosen elm-css version bounds

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -13,7 +13,7 @@
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0",
-        "rtfeldman/elm-css": "15.1.0 <= v < 16.0.0"
+        "rtfeldman/elm-css": "15.1.0 <= v < 17.0.0"
     },
     "test-dependencies": {}
 }

--- a/example/elm.json
+++ b/example/elm.json
@@ -7,17 +7,16 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
             "elm/html": "1.0.0",
-            "elm/json": "1.0.0",
-            "rtfeldman/elm-css": "15.1.0"
+            "elm/json": "1.1.3",
+            "rtfeldman/elm-css": "16.1.0"
         },
         "indirect": {
-            "Skinney/murmur3": "2.0.7",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
             "rtfeldman/elm-hex": "1.0.0"
         }
     },


### PR DESCRIPTION
Fixes issues caused by Skinney/murmur3 github name change
https://discourse.elm-lang.org/t/skinney-murmur3-not-downloading/6285

I've update the example to use the latest elm-css version, let me know if that's an issue